### PR TITLE
Display cars in a multi-column view

### DIFF
--- a/components/NewCar.tsx
+++ b/components/NewCar.tsx
@@ -204,9 +204,9 @@ const NewCar: FunctionComponent<Props> = ({ car, onGray, showValue }) => (
           .info-item {
             margin-right: 16px;
           }
-        }
+        } 
 
-        @media screen and (min-width: 768px) {
+        {/* @media screen and (min-width: 768px) {
           article {
             display: flex;
             margin: 0 32px 40px 40px;
@@ -233,7 +233,7 @@ const NewCar: FunctionComponent<Props> = ({ car, onGray, showValue }) => (
             flex-shrink: 0;
             flex-grow: 1;
           }
-        }
+        } */}
       `}
     </style>
   </article>

--- a/components/NewCar.tsx
+++ b/components/NewCar.tsx
@@ -206,34 +206,11 @@ const NewCar: FunctionComponent<Props> = ({ car, onGray, showValue }) => (
           }
         } 
 
-        {/* @media screen and (min-width: 768px) {
-          article {
-            display: flex;
-            margin: 0 32px 40px 40px;
-            align-items: center;
-          }
-
-          .imageBox {
-            display: block;
-            position: relative;
-            width: 40%;
-            flex-grow: 1;
-            align-self: center;
-          }
-
-          .image {
-            border-radius: 2px;
-          }
-
+       @media screen and (min-width: 750px) {
           .content {
-            margin: 0 0 0 32px;
-            padding: 0;
-            width: 330px;
-            max-width: 380px;
-            flex-shrink: 0;
-            flex-grow: 1;
+            padding-left: 0;
           }
-        } */}
+        } 
       `}
     </style>
   </article>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -402,13 +402,15 @@ const New: NextPage<Props> = ({
           </div>
         </header>
 
-        {stableSort(filteredCars, carSorter(sorting)).map((car) => (
-          <Car
-            car={car}
-            key={`${car.make} ${car.model} ${car.subModel} ${car.price}`}
-            showValue={sorting === 'value' || Boolean(filters.value)}
-          />
-        ))}
+        <div className="cars">
+          {stableSort(filteredCars, carSorter(sorting)).map((car) => (
+            <Car
+              car={car}
+              key={`${car.make} ${car.model} ${car.subModel} ${car.price}`}
+              showValue={sorting === 'value' || Boolean(filters.value)}
+            />
+          ))}
+        </div>
 
         {hasFilter && filteredCarCount > 0 && (
           <div className="filters-reset-box">
@@ -446,8 +448,8 @@ const New: NextPage<Props> = ({
       <style jsx>
         {`
           .content {
-            max-width: 1024px;
             margin: 0 auto;
+            padding: 8px;
           }
           header {
             display: flex;
@@ -627,7 +629,7 @@ const New: NextPage<Props> = ({
 
           @media screen and (min-width: 768px) {
             header {
-              padding-left: 40px;
+              padding-left: 120px;
               max-width: none;
               padding-bottom: 40px;
             }
@@ -640,6 +642,17 @@ const New: NextPage<Props> = ({
             .filters-reset-box {
               padding-left: 40px;
               max-width: none;
+            }
+            .cars {
+              display: grid;
+              grid-template-columns: auto auto;
+            }
+          }
+
+          @media screen and (min-width: 1200px) {
+            .cars {
+              grid-template-columns: auto auto auto;
+              grid-gap: 8px;
             }
           }
         `}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -449,7 +449,6 @@ const New: NextPage<Props> = ({
         {`
           .content {
             margin: 0 auto;
-            padding: 8px;
           }
           header {
             display: flex;
@@ -627,7 +626,10 @@ const New: NextPage<Props> = ({
             }
           }
 
-          @media screen and (min-width: 768px) {
+          @media screen and (min-width: 750px) {
+            .content {
+              padding: 8px;
+            }
             header {
               padding-left: 120px;
               max-width: none;
@@ -645,13 +647,7 @@ const New: NextPage<Props> = ({
             }
             .cars {
               display: grid;
-              grid-template-columns: auto auto;
-            }
-          }
-
-          @media screen and (min-width: 1200px) {
-            .cars {
-              grid-template-columns: auto auto auto;
+              grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
               grid-gap: 8px;
             }
           }


### PR DESCRIPTION
Now that there are more than 100 different models it's pretty hard to get an overview scrolling through the long single-file list. On big displays, most of the screen is empty as it is now with only the centre occupied with info on a car. How could it be easier to get an overview? Introducing: Multi-columns. 

Todo:
- [x] Implement a responsive column layout and adjust car spacing
- [ ] Allow users to toggle between the classic single-file view and the multi-column, there could even be different sizes
- [ ] Align non-column content to be centered with a max 1024px with and a 40 px padding
- [ ] Allow expanding images by clicking on them, preferably with a nice animation like [FluidBox](http://terrymun.github.io/Fluidbox/demo/index.html)