### PR TITLE
Bætti inn ascending og descending í „Raða eftir"

### DIFF
--- a/app/newCars.tsx
+++ b/app/newCars.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
+import clsx from 'clsx'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 
 import Car from '../components/NewCar'
@@ -11,8 +12,14 @@ import ActiveFilters from '../components/ActiveFilters'
 import ChatContainer from '../components/ChatContainer'
 import newCars from '../modules/newCars'
 import carFilter from '../modules/carFilter'
-import { Filters, Sorting } from '../types'
-import { carSorter, sortingToQuery } from '../modules/sorting'
+import { Filters, Sorting, SortingDirection } from '../types'
+import {
+  carSorter,
+  defaultDirection,
+  flipDirection,
+  isDefaultDirection,
+  sortingToQuery,
+} from '../modules/sorting'
 import stableSort from '../modules/stableSort'
 
 const useBodyScrollLock = (lock: boolean): void => {
@@ -38,25 +45,42 @@ const useBodyScrollLock = (lock: boolean): void => {
   }, [lock])
 }
 
-const useSorting = (initial: Sorting) => {
+const useSorting = (initial: Sorting, initialDirection: SortingDirection) => {
   const router = useRouter()
   const pathname = usePathname()
   const searchParams = useSearchParams()
   const [sorting, setSorting] = useState<Sorting>(initial)
+  const [direction, setDirection] = useState<SortingDirection>(initialDirection)
 
   useEffect(() => {
     let updatedSearchParams = new URLSearchParams(searchParams)
+    const isDefault = isDefaultDirection(sorting, direction)
 
-    sorting === 'name'
+    sorting === 'name' && isDefault
       ? updatedSearchParams.delete('radaeftir')
       : updatedSearchParams.set('radaeftir', sortingToQuery[sorting])
+
+    isDefault
+      ? updatedSearchParams.delete('ofugt')
+      : updatedSearchParams.set('ofugt', '1')
 
     router.replace(`${pathname}?${updatedSearchParams.toString()}`, {
       scroll: false,
     })
-  }, [sorting])
+  }, [sorting, direction])
 
-  return [sorting, setSorting] as const
+  // Clicking the active sorting flips it, clicking another one starts it in
+  // its default direction
+  const toggleSorting = (value: Sorting) => {
+    if (value === sorting) {
+      setDirection(flipDirection)
+    } else {
+      setSorting(value)
+      setDirection(defaultDirection[value])
+    }
+  }
+
+  return [sorting, direction, toggleSorting] as const
 }
 
 const useFilters = (initial: Filters) => {
@@ -105,14 +129,19 @@ const useFilters = (initial: Filters) => {
 
 interface Props {
   sorting: Sorting
+  direction: SortingDirection
   filters: Filters
 }
 
 export default function NewCars({
   sorting: initialSorting,
+  direction: initialDirection,
   filters: initialFilters,
 }: Props) {
-  const [sorting, setSorting] = useSorting(initialSorting)
+  const [sorting, direction, toggleSorting] = useSorting(
+    initialSorting,
+    initialDirection,
+  )
   const [filters, setFilters] = useFilters(initialFilters)
 
   let [editingFilters, setEditingFilters] = useState<boolean>(false)
@@ -171,7 +200,18 @@ export default function NewCars({
             ['Hröðun', 'acceleration'],
             ['Verði á km', 'value'],
           ]}
-          onClick={setSorting}
+          onClick={toggleSorting}
+          indicator={
+            <span
+              aria-hidden
+              className={clsx(
+                'text-[9px] leading-none transition-transform duration-200 xs:text-[10px]',
+                direction === 'desc' && 'rotate-180',
+              )}
+            >
+              ▲
+            </span>
+          }
         />
 
         <ActiveFilters
@@ -182,14 +222,16 @@ export default function NewCars({
         />
       </header>
 
-      {stableSort(filteredCars, carSorter(sorting)).map((car, index) => (
-        <Car
-          priority={index <= 1}
-          car={car}
-          key={`${car.make} ${car.model} ${car.subModel} ${car.price}`}
-          showValue={sorting === 'value' || Boolean(filters.value)}
-        />
-      ))}
+      {stableSort(filteredCars, carSorter(sorting, direction)).map(
+        (car, index) => (
+          <Car
+            priority={index <= 1}
+            car={car}
+            key={`${car.make} ${car.model} ${car.subModel} ${car.price}`}
+            showValue={sorting === 'value' || Boolean(filters.value)}
+          />
+        ),
+      )}
 
       {hasFilter && filteredCarCount > 0 && (
         <div className="p-4 flex items-center mx-auto max-w-[480px] gap-2 text-xs font-medium mb-10 xs:p-6 md:pl-10 md:max-w-none">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,7 +6,7 @@ import { Filters, Drive } from '../types'
 import NewCars from './newCars'
 import Footer from '../components/Footer'
 import { ParsedUrlQuery } from 'querystring'
-import { getSortingFromQuery } from '../modules/sorting'
+import { getDirectionFromQuery, getSortingFromQuery } from '../modules/sorting'
 
 export const metadata: Metadata = {
   title: 'Veldu Rafbíl',
@@ -42,6 +42,7 @@ export default async function Page({ searchParams }: Props) {
     <main>
       <NewCars
         sorting={getSortingFromQuery(await searchParams)}
+        direction={getDirectionFromQuery(await searchParams)}
         filters={getFiltersFromQuery(await searchParams)}
       />
       <Footer />

--- a/components/Toggles.tsx
+++ b/components/Toggles.tsx
@@ -1,19 +1,27 @@
+import { ReactNode } from 'react'
 import clsx from 'clsx'
 
 interface Props<P> {
   items: Array<[string, P]>
   onClick: (value: P) => void
   currentValue: P | undefined
+  /** Optional adornment rendered after the label of the active item */
+  indicator?: ReactNode
 }
 
-export default function Toggles<P>({ items, onClick, currentValue }: Props<P>) {
+export default function Toggles<P>({
+  items,
+  onClick,
+  currentValue,
+  indicator,
+}: Props<P>) {
   return (
     <div className="flex max-w-full bg-black/4 self-start rounded-[10px] p-[3px] gap-[3px] xs:rounded-xl xs:p-1 xs:gap-1">
       {items.map(([label, value]) => (
         <div
           key={label}
           className={clsx(
-            'text-xs font-semibold py-[7px] px-3 cursor-pointer text-center flex justify-center items-center whitespace-nowrap min-w-0 rounded-[7px] transition-all duration-200 ease-out relative',
+            'text-xs font-semibold py-[7px] px-3 cursor-pointer text-center flex justify-center items-center whitespace-nowrap min-w-0 rounded-[7px] transition-all duration-200 ease-out relative gap-1',
             'xs:text-[13px] xs:py-2 xs:px-4 xs:rounded-lg',
             value === currentValue
               ? 'bg-white text-tint shadow-sm'
@@ -22,6 +30,7 @@ export default function Toggles<P>({ items, onClick, currentValue }: Props<P>) {
           onClick={() => onClick(value)}
         >
           {label}
+          {value === currentValue && indicator}
         </div>
       ))}
     </div>

--- a/modules/sorting.ts
+++ b/modules/sorting.ts
@@ -1,5 +1,10 @@
 import getKmPerMinutesCharged from './getKmPerMinutesCharged'
-import { NewCar, Sorting, SortingQuery } from '../types'
+import {
+  NewCar,
+  Sorting,
+  SortingDirection,
+  SortingQuery,
+} from '../types'
 import getPriceWithGrant from './getPriceWithGrant'
 
 const queryToSorting: Record<string, Sorting> = {
@@ -20,13 +25,39 @@ export const sortingToQuery: Record<Sorting, SortingQuery> = {
   fastcharge: 'hradhledslu',
 }
 
+// The direction each sorting starts in, i.e. the "most useful first" order
+export const defaultDirection: Record<Sorting, SortingDirection> = {
+  name: 'asc',
+  price: 'asc',
+  range: 'desc',
+  acceleration: 'asc',
+  value: 'asc',
+  fastcharge: 'desc',
+}
+
+export const flipDirection = (direction: SortingDirection): SortingDirection =>
+  direction === 'asc' ? 'desc' : 'asc'
+
 export const getSortingFromQuery = ({ radaeftir }: Record<string, string>) =>
   radaeftir in queryToSorting ? queryToSorting[radaeftir] : 'name'
+
+export const getDirectionFromQuery = (
+  query: Record<string, string>,
+): SortingDirection => {
+  const base = defaultDirection[getSortingFromQuery(query)]
+  return query.ofugt === '1' ? flipDirection(base) : base
+}
+
+export const isDefaultDirection = (
+  sorting: Sorting,
+  direction: SortingDirection,
+): boolean => defaultDirection[sorting] === direction
 
 const padPrice = (car: NewCar): string =>
   getPriceWithGrant(car.price).toString().padStart(9, '0')
 
-export const carSorter =
+// Always ascending on the underlying value, direction is applied afterwards
+const ascendingSorter =
   (sorting: Sorting) =>
   (a: NewCar, b: NewCar): number => {
     switch (sorting) {
@@ -37,7 +68,7 @@ export const carSorter =
       case 'price':
         return getPriceWithGrant(a.price) - getPriceWithGrant(b.price)
       case 'range':
-        return b.range - a.range
+        return a.range - b.range
       case 'acceleration':
         return a.acceleration - b.acceleration
       case 'value':
@@ -47,8 +78,15 @@ export const carSorter =
         )
       case 'fastcharge':
         return (
-          Number(getKmPerMinutesCharged(b.timeToCharge10T080, b.range)) -
-          Number(getKmPerMinutesCharged(a.timeToCharge10T080, a.range))
+          Number(getKmPerMinutesCharged(a.timeToCharge10T080, a.range)) -
+          Number(getKmPerMinutesCharged(b.timeToCharge10T080, b.range))
         )
     }
+  }
+
+export const carSorter =
+  (sorting: Sorting, direction: SortingDirection = defaultDirection[sorting]) =>
+  (a: NewCar, b: NewCar): number => {
+    const result = ascendingSorter(sorting)(a, b)
+    return direction === 'asc' ? result : -result
   }

--- a/types.d.ts
+++ b/types.d.ts
@@ -75,6 +75,8 @@ export type Sorting =
   | 'value'
   | 'fastcharge'
 
+export type SortingDirection = 'asc' | 'desc'
+
 export type SortingQuery =
   | 'nafni'
   | 'verdi'


### PR DESCRIPTION
Nú er hægt að smella aftur á virka röðun í „Raða eftir" til að snúa röðinni við (ascending/descending). Ör við virka valmöguleikann sýnir stefnuna.

- Hver röðun byrjar í sinni gagnlegustu átt (t.d. drægni lengst fyrst, verð lægst fyrst) og smellur á sömu röðun snýr henni við
- Stefnan helst í slóðinni með `ofugt=1` svo röðunin lifir af endurhleðslu og er deilanleg
- `carSorter` raðar nú alltaf ascending og stefnan er lögð ofan á eftir á, í stað þess að hver röðun harðkóði sína átt

🤖 Generated with [Claude Code](https://claude.com/claude-code)